### PR TITLE
CMake cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@ set(VERSION "2.1.3")
 # Specify where we're dropping things- the end-user of this system
 # can specify elsewhere, but we're going to pour it here to make
 # it easier on us...
-SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/build)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
+    SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/build)
+endif()
 
 # Do our up-front config checks...
 INCLUDE(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/build)
 INCLUDE(GNUInstallDirs)
 INCLUDE(ConfigureChecks.cmake)
 
+# Declare our project's additional include path entries...
+INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 # Add the various subdirectories for sourcecode, etc...
 ADD_SUBDIRECTORY(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,8 @@ INCLUDE(GNUInstallDirs)
 INCLUDE(ConfigureChecks.cmake)
 
 # Declare our project's additional include path entries...
-INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/include)
+INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_BINARY_DIR}/include)
 
 # Add the various subdirectories for sourcecode, etc...
 ADD_SUBDIRECTORY(src)

--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -33,6 +33,5 @@ else (SIZEOF_LONG EQUAL 4)
 	endif (SIZEOF_LONG EQUAL 8)
 endif (SIZEOF_LONG EQUAL 4)
 
-
-# Jam out a config.h in the sources directory...
-CONFIGURE_FILE(include/config.h.in include/config.h)
+# Jam out a config.h
+CONFIGURE_FILE(include/config.h.in ${CMAKE_BINARY_DIR}/include/config.h)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,3 @@
-
-# Declare our project's additional include path entries...
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${CMAKE_SOURCE_DIR}/include")
-
 # Bring in/build our library components...
 ADD_SUBDIRECTORY(lib)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,4 +39,17 @@ ADD_EXECUTABLE(chpst chpst.c)
 TARGET_LINK_LIBRARIES(chpst runit_runtime)
 
 # Set destinations for things...binaries go in /usr/sbin or /usr/local/sbin...
-INSTALL(DIRECTORY ${CMAKE_SOURCE_DIR}/build/. DESTINATION ${CMAKE_INSTALL_SBINDIR} FILES_MATCHING PATTERN "*")
+INSTALL(TARGETS
+    runit
+    runit-init
+    runsv
+    runsvdir
+    runsvstat
+    runsvcrtl
+    sv
+    svwaitup
+    svwaitdown
+    utmpset
+    runsvchdir
+    chpst
+    DESTINATION ${CMAKE_INSTALL_SBINDIR})


### PR DESCRIPTION
The canonical way to not put things at random locations in the source directory is:

```sh
mkdir build
cd build
cmake /path/to/source
```

Keep things in build subdirectory for people to build in source, but don't clutter the source directory for everyone else. This allows easy parallel build in multiple directories with distinct compilers/settings.