### PR TITLE
CMake: require correct minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # a version for testing with later cmake, EXPERIMENTAL....
 
-CMAKE_MINIMUM_REQUIRED (VERSION 2.8)
+CMAKE_MINIMUM_REQUIRED (VERSION 2.8.8)
 PROJECT (runit)
 set(VERSION "2.1.3")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # a version for testing with later cmake, EXPERIMENTAL....
 
 CMAKE_MINIMUM_REQUIRED (VERSION 2.8.8)
-PROJECT (runit)
+PROJECT (runit C)
 set(VERSION "2.1.3")
 
 # Specify where we're dropping things- the end-user of this system


### PR DESCRIPTION
According to [CMake documentation](https://cmake.org/Wiki/CMake_Version_Compatibility_Matrix/Commands#cite_note-9) this is missing in 2.8.7. While at it avoid searching for a C++ compiler that is not used afterwards.